### PR TITLE
Add applied tx structure to the mutable data. (#168)

### DIFF
--- a/include/waflz/def.h
+++ b/include/waflz/def.h
@@ -96,12 +96,21 @@ typedef struct _data {
 } data_t;
 typedef struct _mutable_data {
         char *m_data;
+        uint16_t m_tx_applied;
         uint32_t m_len;
         _mutable_data():
                 m_data(NULL),
+                m_tx_applied(0),
                 m_len(0)
         {}
 } mutable_data_t;
+
+typedef enum tx_applied
+{
+        TX_APPLIED_TOLOWER = 1 << 0,
+        TX_APPLIED_CMDLINE = 1 << 1
+} tx_applied_t;
+
 typedef std::list <data_t> data_list_t;
 struct data_case_i_comp
 {

--- a/src/core/op.cc
+++ b/src/core/op.cc
@@ -71,6 +71,16 @@
                                       macro* a_macro, \
                                       rqst_ctx *a_ctx)
 namespace ns_waflz {
+
+//: ----------------------------------------------------------------------------
+//: \details: Checks if a context object was marked with a tx that uses tolower()
+//: \param:   A context(output)
+//: \return:  True if a tx that uses tolower() was called.
+//: ----------------------------------------------------------------------------
+static bool check_if_tolower_tx_was_applied(ns_waflz::rqst_ctx *a_ctx) {
+        return (a_ctx->m_src_asn_str.m_tx_applied & ns_waflz::TX_APPLIED_TOLOWER) ||
+                (a_ctx->m_src_asn_str.m_tx_applied & ns_waflz::TX_APPLIED_CMDLINE);
+}
 //: ----------------------------------------------------------------------------
 //: ****************************************************************************
 //:                             O P E R A T I O N S
@@ -715,7 +725,9 @@ OP(PM)
         // -------------------------------------------------
         ac *l_ac = (ac *)(a_op._reserved_1());
         bool l_match = false;
-        l_match = l_ac->find_first(a_buf, a_len);
+        const bool l_tolower_applied = check_if_tolower_tx_was_applied(a_ctx);
+        l_match = l_ac->find_first(a_buf, a_len, l_tolower_applied);
+        //NDBG_PRINT("l_tolower_applied - %d\n", l_tolower_applied);
         if(l_match)
         {
                 ao_match = true;
@@ -747,7 +759,9 @@ OP(PMF)
         // -------------------------------------------------
         ac *l_ac = (ac *)(a_op._reserved_1());
         bool l_match = false;
-        l_match = l_ac->find_first(a_buf, a_len);
+        const bool l_tolower_applied = check_if_tolower_tx_was_applied(a_ctx);
+        l_match = l_ac->find_first(a_buf, a_len, l_tolower_applied);
+        //NDBG_PRINT("l_tolower_applied - %d\n", l_tolower_applied);
         if(l_match)
         {
                 ao_match = true;
@@ -779,7 +793,9 @@ OP(PMFROMFILE)
         // -------------------------------------------------
         ac *l_ac = (ac *)(a_op._reserved_1());
         bool l_match = false;
-        l_match = l_ac->find_first(a_buf, a_len);
+        const bool l_tolower_applied = check_if_tolower_tx_was_applied(a_ctx);
+        l_match = l_ac->find_first(a_buf, a_len, l_tolower_applied);
+        //NDBG_PRINT("l_tolower_applied - %d\n", l_tolower_applied);
         if(l_match)
         {
                 ao_match = true;

--- a/src/core/waf.cc
+++ b/src/core/waf.cc
@@ -46,7 +46,40 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <errno.h>
+
 namespace ns_waflz {
+
+//: ----------------------------------------------------------------------------
+//: \details: Mark the context with the applied tx. This can be used to avoid
+//:           performing the same logic more than once. ie: tolower() on a
+//:           particular operation that uses the ac when a previous tx already
+//:           lowered the string.
+//: \param:   A context(output)
+//: \param:   A transformation type.
+//: \return:  Sets the context with the appropiated applied tx.
+//: ----------------------------------------------------------------------------
+static void mark_tx_applied(ns_waflz::rqst_ctx *a_ctx,
+                waflz_pb::sec_action_t_transformation_type_t const &tx_type)
+{
+        switch(tx_type)
+        {
+        case waflz_pb::sec_action_t_transformation_type_t::
+                sec_action_t_transformation_type_t_LOWERCASE:
+        {
+                a_ctx->m_src_asn_str.m_tx_applied |= ns_waflz::TX_APPLIED_TOLOWER;
+                break;
+        }
+        case waflz_pb::sec_action_t_transformation_type_t::
+                sec_action_t_transformation_type_t_CMDLINE:
+        {
+                a_ctx->m_src_asn_str.m_tx_applied |= ns_waflz::TX_APPLIED_CMDLINE;
+                break;
+        }
+        default:;
+                // TODO: CMDLINE tx will also apply tolower(), Should it be included?
+        }
+}
+
 //: ----------------------------------------------------------------------------
 //: \details: TODO
 //: \return:  TODO
@@ -1636,6 +1669,10 @@ int32_t waf::process_rule_part(waflz_pb::event **ao_event,
                                         // TODO log reason???
                                         return WAFLZ_STATUS_ERROR;
                                 }
+                                // mark the current transformation so the operation can check and decide if some actions
+                                // like lowering the string needs to be done by the rule. Having this we can avoid things
+                                // like calling tolower() twice on the same string.
+                                mark_tx_applied(&a_ctx, l_t_type);
                                 if(l_mutated)
                                 {
                                         free(const_cast <char *>(l_x_data));
@@ -1724,6 +1761,7 @@ run_op:
                                 l_x_data = NULL;
                                 l_x_len = 0;
                                 l_mutated = false;
+                                a_ctx.m_src_asn_str.m_tx_applied = 0; // Reset
                         }
                         // ---------------------------------
                         // got a match -outtie

--- a/src/op/ac.cc
+++ b/src/op/ac.cc
@@ -544,7 +544,8 @@ int32_t ac::finalize(void)
 //: \return:  TODO
 //: \param:   TODO
 //: ----------------------------------------------------------------------------
-bool ac::find(const char *a_buf, uint32_t a_len, match_cb_t a_cb, void *a_data)
+bool ac::find(const char *a_buf, uint32_t a_len, match_cb_t a_cb, void *a_data,
+              bool a_override_case_sensitive)
 {
         if(!m_finalized)
         {
@@ -561,7 +562,7 @@ bool ac::find(const char *a_buf, uint32_t a_len, match_cb_t a_cb, void *a_data)
                 // -----------------------------------------
                 // force char to lower if NOT case sensitive
                 // -----------------------------------------
-                if(!m_cfg_case_sensitive)
+                if(!m_cfg_case_sensitive && !a_override_case_sensitive)
                 {
 #ifdef _AC_UTF8
                         if(m_cfg_utf8)
@@ -571,7 +572,7 @@ bool ac::find(const char *a_buf, uint32_t a_len, match_cb_t a_cb, void *a_data)
                         else
                         {
 #endif
-                        l_c = tolower(l_c);
+                                l_c = tolower(l_c);
 #ifdef _AC_UTF8
                         }
 #endif
@@ -619,9 +620,9 @@ bool ac::find(const char *a_buf, uint32_t a_len, match_cb_t a_cb, void *a_data)
 //: \return:  TODO
 //: \param:   TODO
 //: ----------------------------------------------------------------------------
-bool ac::find_first(const char *a_buf, uint32_t a_len)
+bool ac::find_first(const char *a_buf, uint32_t a_len, bool a_override_case_sensitive)
 {
-        return find(a_buf, a_len, match_handler_find_first, NULL);
+        return find(a_buf, a_len, match_handler_find_first, NULL, a_override_case_sensitive);
 }
 //: ----------------------------------------------------------------------------
 //: \details: TODO

--- a/src/op/ac.h
+++ b/src/op/ac.h
@@ -90,8 +90,15 @@ public:
         ~ac();
         int32_t add(const char *a_buf, uint32_t a_len);
         int32_t finalize(void);
-        bool find(const char *a_buf, uint32_t a_len, match_cb_t a_cb, void *a_data);
-        bool find_first(const char *a_buf, uint32_t a_len);
+        bool find(const char *a_buf, uint32_t a_len, match_cb_t a_cb,
+                  void *a_data,
+                  bool a_override_case_sensitive =
+                      false); //!< override case sensitive
+
+        bool find_first(const char *a_buf, uint32_t a_len,
+                        bool a_override_case_sensitive =
+                            false); //!< override case sensitive
+
         const char *get_err_msg(void) { return m_err_msg; }
 #ifdef AC_DEBUG
         void display(void);


### PR DESCRIPTION
* Add applied tx structure to the mutable data in order to keep track of the applied transformations.

* Add CMDLINE tx to the applied transformation history.

Co-authored-by: Damian Meden <damian.meden@verizonmedia.com>
Co-authored-by: Reed Morrison <reed.morrison@gmail.com>
(cherry picked from commit 3a07365c04c17c5e0b461c496da3703b05e70e24)